### PR TITLE
Converted validate_students to use RAM based storage

### DIFF
--- a/automation.py
+++ b/automation.py
@@ -1,4 +1,3 @@
-import mss
 import time
 import capture
 import numpy as np
@@ -97,12 +96,7 @@ def validate_students(x, y, width, height, search_bar, input_file, output_file, 
         meeting_label = capture.find_img_coordinates("in_the_meeting_label.png", "meeting")
 
         if meeting_label is not None:
-            with mss.mss() as sct:
-                wait_list = capture.get_text_coordinates(np.array(sct.grab({'top': int(y),
-                                                                            'left': int(x),
-                                                                            'width': int(width),
-                                                                            'height': int(height)})))
-            wait_name = set(student['Text'].replace('‘','') for student in wait_list)
+            wait_name = set(student['Text'].replace('‘','') for student in capture.get_text_coordinates(x, y, width, height))
 
             present_students = wait_name.intersection(students)
             absent_students = students.difference(wait_name)

--- a/automation.py
+++ b/automation.py
@@ -1,7 +1,8 @@
 import capture
+import time
+import numpy as np
 import pandas as pd
 import pyautogui as pug
-import time
 
 from tkinter import filedialog
 
@@ -95,9 +96,10 @@ def validate_students(x, y, width, height, search_bar, input_file, output_file, 
         meeting_label = capture.find_img_coordinates("in_the_meeting_label.png", "meeting")
 
         if meeting_label is not None:
-            capture.waiting_ss(x, y, width, height, "meeting")
-
-            wait_list = capture.get_text_coordinates("waiting_list.png", "meeting")
+            wait_list = capture.get_text_coordinates(np.array(sct.grab({'top': int(ypos),
+                                                                        'left': int(xpos),
+                                                                        'width': int(width),
+                                                                        'height': int(height)})))
             wait_name = set(student['Text'].replace('‘','') for student in wait_list)
 
             present_students = wait_name.intersection(students)

--- a/automation.py
+++ b/automation.py
@@ -1,5 +1,6 @@
-import capture
+import mss
 import time
+import capture
 import numpy as np
 import pandas as pd
 import pyautogui as pug
@@ -96,10 +97,11 @@ def validate_students(x, y, width, height, search_bar, input_file, output_file, 
         meeting_label = capture.find_img_coordinates("in_the_meeting_label.png", "meeting")
 
         if meeting_label is not None:
-            wait_list = capture.get_text_coordinates(np.array(sct.grab({'top': int(ypos),
-                                                                        'left': int(xpos),
-                                                                        'width': int(width),
-                                                                        'height': int(height)})))
+            with mss.mss() as sct:
+                wait_list = capture.get_text_coordinates(np.array(sct.grab({'top': int(ypos),
+                                                                            'left': int(xpos),
+                                                                            'width': int(width),
+                                                                            'height': int(height)})))
             wait_name = set(student['Text'].replace('‘','') for student in wait_list)
 
             present_students = wait_name.intersection(students)

--- a/automation.py
+++ b/automation.py
@@ -98,8 +98,8 @@ def validate_students(x, y, width, height, search_bar, input_file, output_file, 
 
         if meeting_label is not None:
             with mss.mss() as sct:
-                wait_list = capture.get_text_coordinates(np.array(sct.grab({'top': int(ypos),
-                                                                            'left': int(xpos),
+                wait_list = capture.get_text_coordinates(np.array(sct.grab({'top': int(y),
+                                                                            'left': int(x),
                                                                             'width': int(width),
                                                                             'height': int(height)})))
             wait_name = set(student['Text'].replace('‘','') for student in wait_list)

--- a/automation.py
+++ b/automation.py
@@ -96,7 +96,8 @@ def validate_students(x, y, width, height, search_bar, input_file, output_file, 
         meeting_label = capture.find_img_coordinates("in_the_meeting_label.png", "meeting")
 
         if meeting_label is not None:
-            wait_name = set(student['Text'].replace('‘','') for student in capture.get_text_coordinates(x, y, width, height))
+            wait_list = capture.get_text_coordinates(x, y, width, height)
+            wait_name = set(student['Text'].replace('‘','') for student in wait_list)
 
             present_students = wait_name.intersection(students)
             absent_students = students.difference(wait_name)

--- a/automation.py
+++ b/automation.py
@@ -9,13 +9,13 @@ def setup_df(input_file, output_file):
     student_df = pd.read_csv(input_file)
     student_df.fillna('NA', inplace=True)
     student = {'Student ID': [], 'Name': [], 'Status': [], 'Time': [], 'Date': []}
-    
+
     students = []
     for r in range(0, len(student_df.iloc[:, 1:])):
         for c in student_df.iloc[r, 1:]:
             if c != "NA":
                 students.append(c)
-    
+
     for s in sorted(students):
         info = s.replace(',', '').split(' ')
 
@@ -31,9 +31,9 @@ def setup_df(input_file, output_file):
 
 def attendance(input_file, output_file, category):
     dot_btn = capture.find_img_coordinates("dot_btn.png", "meeting")
-    
+
     if dot_btn is not None:
-        
+
         search_bar = capture.find_img_coordinates("participants_search.png", "meeting")
 
         if search_bar is not None:
@@ -62,7 +62,7 @@ def validate_students(x, y, width, height, search_bar, input_file, output_file, 
 
     if leader:
         in_df = pd.read_csv(input_file)
-        
+
         for r in range(len(in_df.iloc[:, 1])):
             info = (in_df.iloc[r, 1]).replace(',', '').split(' ')
             name = info[1] + ' ' + info[0]
@@ -86,24 +86,24 @@ def validate_students(x, y, width, height, search_bar, input_file, output_file, 
                         continue
                     else:
                         students.add(c.lower())
-    
+
     for name in students:
         print(name)
         pug.click(search_bar)
         pug.typewrite(name)
 
         meeting_label = capture.find_img_coordinates("in_the_meeting_label.png", "meeting")
-        
+
         if meeting_label is not None:
             capture.waiting_ss(x, y, width, height, "meeting")
 
             wait_list = capture.get_text_coordinates("waiting_list.png", "meeting")
             wait_name = set(student['Text'].replace('‘','') for student in wait_list)
-            
+
             present_students = wait_name.intersection(students)
             absent_students = students.difference(wait_name)
             print("SIZE: " + str(len(absent_students)))
-            
+
             record_student(x, y, present_students, absent_students, wait_list, output_file, leader)
             search()
 
@@ -132,7 +132,7 @@ def record_student(x, y, present_set, absent_set, wait_list, output_file, leader
                     output_df.iat[r, 2] = "ABSENT"
 
             output_df.iat[r, 3] = time.strftime('%H:%M:%S', time.localtime())
-    
+
     output_df.to_csv(output_file, index=False)
 
     global student_prep, leader_prep
@@ -144,7 +144,7 @@ def record_student(x, y, present_set, absent_set, wait_list, output_file, leader
 
 def admit_student(x, y, student, wait_list):
     match = None
-    
+
     for person in wait_list:
         if person['Text'] == student:
             print("FOUND: " + student)
@@ -152,6 +152,4 @@ def admit_student(x, y, student, wait_list):
 
     if match is not None:
         pug.moveTo(x + match['Coordinates']['x'], y + match['Coordinates']['y'])
-        capture.waiting_ss(wait_x, wait_y, wait_w, wait_h, "meeting")
         pug.click(pug.locateOnScreen('images/meeting/admit_btn.png', grayscale=True))
-              

--- a/capture.py
+++ b/capture.py
@@ -10,13 +10,6 @@ from PIL import Image
 from pytesseract import Output
 
 # pytesseract.pytesseract.tesseract_cmd = 'Tesseract-OCR\\tesseract.exe'
-def waiting_ss(xpos, ypos, width, height, img_folder):
-    with mss.mss() as sct:
-        area = {'top': int(ypos), 'left': int(xpos), 'width': int(width), 'height': int(height)}
-
-        area_img = sct.grab(area)
-        mss.tools.to_png(area_img.rgb, area_img.size, output="images/" + img_folder + "/waiting_list.png")
-
 
 def find_img_coordinates(img_name, img_folder):
     with mss.mss() as sct:

--- a/capture.py
+++ b/capture.py
@@ -1,10 +1,10 @@
-import cv2
+import re
 import os
+import cv2
+import numpy as np
+import pytesseract
 import mss, mss.tools
 import pyautogui as pug
-import pytesseract
-import numpy as np
-import re
 
 from PIL import Image
 from pytesseract import Output
@@ -13,7 +13,7 @@ from pytesseract import Output
 def waiting_ss(xpos, ypos, width, height, img_folder):
     with mss.mss() as sct:
         area = {'top': int(ypos), 'left': int(xpos), 'width': int(width), 'height': int(height)}
-        
+
         area_img = sct.grab(area)
         mss.tools.to_png(area_img.rgb, area_img.size, output="images/" + img_folder + "/waiting_list.png")
 
@@ -32,9 +32,10 @@ def find_img_coordinates(img_name, img_folder):
         return None
 
 
-def get_text_coordinates(img_name, img_folder):
-    img = cv2.imread("images/" + img_folder + '/' + img_name)
-    gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+def get_text_coordinates(img_as_np: np.ndarray):
+    if not isinstance(img_as_np, np.ndarray):
+        raise TypeError(f"get_text_coordinates() argument must be a numpy.ndarray, not {type(img_as_np).__name__!r}")
+    gray = cv2.cvtColor(img_as_np, cv2.COLOR_BGR2GRAY)
     d = pytesseract.image_to_data(gray, output_type=Output.DICT)
 
     text_coords = []
@@ -65,5 +66,5 @@ def get_text_coordinates(img_name, img_folder):
                     #     (x + w + w2 + 10, y + h),
                     #     (0, 0, 255), 2)
                     # cv2.imshow('Output', gray)
-                    
+
     return text_coords

--- a/capture.py
+++ b/capture.py
@@ -25,10 +25,12 @@ def find_img_coordinates(img_name, img_folder):
         return None
 
 
-def get_text_coordinates(img_as_np: np.ndarray):
-    if not isinstance(img_as_np, np.ndarray):
-        raise TypeError(f"get_text_coordinates() argument must be a numpy.ndarray, not {type(img_as_np).__name__!r}")
-    gray = cv2.cvtColor(img_as_np, cv2.COLOR_BGR2GRAY)
+def get_text_coordinates(x, y, width, height):
+    with mss.mss() as sct:
+        gray = cv2.cvtColor(np.array(sct.grab({'top': int(y),
+                                               'left': int(x),
+                                               'width': int(width),
+                                               'height': int(height)})), cv2.COLOR_BGR2GRAY)
     d = pytesseract.image_to_data(gray, output_type=Output.DICT)
 
     text_coords = []


### PR DESCRIPTION
Initially, `validate_students` relied on a function called `waiting_ss` which stored a screenshot to the disk almost exactly like the situation in #1.  This pull request now stores the image that would have been written the disk in a numpy array which is stored in RAM.  Once the numpy array is utilized it is presumably deleted from RAM by the garbage collector.  Storing the image in RAM prevents a permissions error which is described in more detail in #1.